### PR TITLE
Fix finding-minecraft-data-folder typos and formatting issues

### DIFF
--- a/_help/finding-minecraft-data-folder/index.markdown
+++ b/_help/finding-minecraft-data-folder/index.markdown
@@ -9,11 +9,9 @@ desc: "How to find your .minecraft folder"
 You may need to find the Minecraft data folder for many reasons, the following is a guide to do so.
 
 ### Windows
-To find the Minecraft data folder on Windows, hold down the Windows key (usually a picture of the Windows logo, and typically between the Control and Alt key, usually to the left of the space bar) and then press the R key without letting go. A box should pop up, titled Run. In that box, you need to type `%appdata%\.minecraft`, then click the OK button.
+To find the Minecraft data folder on Windows, hold down the Windows key (usually a picture of the Windows logo, and typically between the Control and Alt key, usually to the left of the space bar) and then press the R key without letting go. A box should pop up, titled "Run". In that box, you need to type `%appdata%\.minecraft`, then click the OK button.
 
 ![Screenshot of Win-R Menu](/static/images/help/finding-minecraft-data-folder/Windows.png) 
-=======
-![Screenshot of Win-R Menu](/static/images/help/finding-minecraft-data-folder/macOS.png)
 
 ### macOS
 Triple click the line below to select it, then right click (hold control and click) and select Services > Show in Finder
@@ -24,9 +22,9 @@ If you are unable to complete these steps, then try this:
 
 1. Switch to Finder
 2. Press ⌘ + Shift + G
-4. Type `~/Library/Application Support/minecraft`
-5. Press Go
+3. Type `~/Library/Application Support/minecraft`
+4. Press Go  
 ![Screenshot of Finder Go menu](/static/images/help/finding-minecraft-data-folder/macOS.png)
 
-## Linux
-On Linux, the Minecraft data folder is located in `/home/user/.minecraft.` 
+### Linux
+On Linux, the Minecraft data folder is located in `/home/user/.minecraft`. 


### PR DESCRIPTION
Fixes some typos and formatting issues.

Also the steps for macOS seems to be missing something:
> Triple click the line below to select it

Which "line below" and what is "it"?