### PR TITLE
Fix wrong article titles

### DIFF
--- a/_help/exit-code/code-1073741819/index.markdown
+++ b/_help/exit-code/code-1073741819/index.markdown
@@ -1,10 +1,10 @@
 ---
 layout: article
-title:  "Exit Code: -107374181"
+title:  "Exit Code: -1073741819"
 name: "ec-107374181"
-desc: "Exit Code: -107374181"
+desc: "Exit Code: -1073741819"
 ---
-# Exit Code: -107374181 <small>(HEX: 0xC0000005 - STATUS_ACCESS_VIOLATION)</small>
+# Exit Code: -1073741819 <small>(HEX: 0xC0000005 - STATUS_ACCESS_VIOLATION)</small>
 We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/exit-code/code-1073740777) installed.
 ## How to fix this
 Due to the quite vagueness of the error, we are unsure of the exact cause. Please try the following and attempt to see it they solve your case:

--- a/_help/incompatible-class-change-error/index.markdown
+++ b/_help/incompatible-class-change-error/index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: article
-title: "incompatible-class-change-error"
-name: "Incompatible Class Change Error"
+title: "Incompatible Class Change Error"
+name: "incompatible-class-change-error"
 desc: "Incompatible Class Change Error in Minecraft"
 ---
 

--- a/_help/internet-crash-att2wire-02/index.markdown
+++ b/_help/internet-crash-att2wire-02/index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: article
-title: "incompatible-class-change-error"
-name: "Incompatible Class Change Error"
+title: "Internet Crash on AT&T 2Wire"
+name: "internet-crash-att2wire-02"
 desc: "How to fix Internet Crash on AT&T 2Wire in Minecraft"
 ---
 # Internet Crash on AT&T 2Wire

--- a/_help/invalid-data-sent-by-server/index.markdown
+++ b/_help/invalid-data-sent-by-server/index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: article
-title: "invalid-data-sent-by-server"
-name: "Invalid Data Sent By Server"
+title: "Invalid Data Sent By Server"
+name: "invalid-data-sent-by-server"
 desc: "Invalid Data Sent By Server - Affecting 1.8"
 ---
 

--- a/_help/modifier-name/index.markdown
+++ b/_help/modifier-name/index.markdown
@@ -1,7 +1,7 @@
 ---
 layout: article
 title:  "Modifier Name Cannot Be Empty"
-name: "modifer-name"
+name: "modifier-name"
 desc: "How to fix Modifier Name Cannot Be Empty in Minecraft"
 ---
 # Modifier Name Cannot Be Empty


### PR DESCRIPTION
This also fixes a article URL typo for `modifier-name`. Should a redirect be added for this?