### PR TITLE
Fix issues with special characters page

### DIFF
--- a/_help/guides/changing-work-directory/index.markdown
+++ b/_help/guides/changing-work-directory/index.markdown
@@ -29,7 +29,7 @@ At the end of the 'Target' bar, add the following:
 
 It should then look like this:
 
-![](static/images/help/guides/changing-work-directory/changing-work-directory-3.png)
+![](/static/images/help/guides/changing-work-directory/changing-work-directory-3.png)
 
 **Step 4**
 

--- a/_help/special-characters/index.markdown
+++ b/_help/special-characters/index.markdown
@@ -10,7 +10,7 @@ desc: "Special Characters"
 
 Having an exclamation point (!), or some non-English Alphanumeric characters in your Windows User Account name will cause the game to crash.
 
-In some cases you can fix this by changing the working directory the game uses by following the instructions here.
+In some cases you can fix this by changing the working directory the game uses to a path that does not contain an explanation point by following the instructions [here](/help/guides/changing-work-directory/).
 
 If that does not resolve the issue, you will need to create a new local Windows User Account containing only English alphanumernic characters (a to z, A to Z, 0 to 9).
 


### PR DESCRIPTION
There is no link to the changing working directory guide, and the working directory guide has a broken image link.  (I've confirmed that the working directory guide is the only one with a link broken like that)