### PR TITLE
Add DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@ _site
 .sass-cache
 .jekyll-metadata
 .idea/
-
+.DS_Store
 Jekyll.sh


### PR DESCRIPTION
This ensures that contributors who have Macs can work with the folders without DS_Store files polluting the server's repository. If this was the wrong way to go about making such a small change...oops