### PR TITLE
Add ADWCleaner as a solution exit code -805306369 article

### DIFF
--- a/_help/exit-code/code-805306369/index.markdown
+++ b/_help/exit-code/code-805306369/index.markdown
@@ -10,6 +10,7 @@ This exit code is caused when the client runs out of memory.<br>
 This can be caused by the JVM not being allocated enough memory, a bug in the game, using client modifications or a dependency of the game that has unexpectedly terminated.
 #### How to fix this
 - See [this article](/help/out-of-memory/) on instructions to allocate more memory.
+- [Run an ADWCleaner scan](https://downloads.malwarebytes.com/file/adwcleaner)
 - [Run a Malwarebytes scan](https://support.malwarebytes.com/docs/DOC-1156)
 - [Reinstall minecraft](/help/reinstalling-minecraft/) to ensure you have no client mods.
 - [Check your System Event Log for issues.](/help/using-event-viewer/)


### PR DESCRIPTION
This closes #94 if we want to do this and it could be changed to say "If you can't run ADWCleaner then please run Malwarebytes"

