### PR TITLE
Fix server article meta tag

### DIFF
--- a/_help/setting-up-java-server/index.markdown
+++ b/_help/setting-up-java-server/index.markdown
@@ -6,6 +6,7 @@ desc: 'How to Setup a Java Edition Server'
 ---
 
 # Setting up a Minecraft: Java Edition server
+
 Minecraft: Java edition uses servers for online play.
 <br>**If you want to temporarily play multiplayer with someone on the same network as you, you can press 'Open to lan' from the minecraft pause screen, and your world should show up for anyone on the same network**
 


### PR DESCRIPTION
Not a big change, but the very long meta tag for https://minecrafthopper.net/help/setting-up-java-server/ on Discord was bothering me