### PR TITLE
Fix broken link (properly this time)

### DIFF
--- a/_help/exit-code/code-1073741819/index.markdown
+++ b/_help/exit-code/code-1073741819/index.markdown
@@ -8,7 +8,7 @@ desc: "Exit Code: -1073741819"
 We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/help/exit-code/code-1073740777/index.markdown) installed.
 ## How to fix this
 Due to the quite vagueness of the error, we are unsure of the exact cause. Please try the following and attempt to see it they solve your case:
-* [This may possibly be caused by having D3Dgear installed. (If that is the case, please let us know!) ](/_help/exit-code/code-1073740777/index.markdown)
+* [This may possibly be caused by having D3Dgear installed. (If that is the case, please let us know!) ](/help/exit-code/code-1073740777/index.markdown)
 * Try updating your graphics drivers.
 
 

--- a/_help/exit-code/code-1073741819/index.markdown
+++ b/_help/exit-code/code-1073741819/index.markdown
@@ -5,7 +5,7 @@ name: "ec-107374181"
 desc: "Exit Code: -1073741819"
 ---
 # Exit Code: -1073741819 <small>(HEX: 0xC0000005 - STATUS_ACCESS_VIOLATION)</small>
-We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/_help/exit-code/code-1073740777/index.markdown) installed.
+We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/help/exit-code/code-1073740777/index.markdown) installed.
 ## How to fix this
 Due to the quite vagueness of the error, we are unsure of the exact cause. Please try the following and attempt to see it they solve your case:
 * [This may possibly be caused by having D3Dgear installed. (If that is the case, please let us know!) ](/_help/exit-code/code-1073740777/index.markdown)

--- a/_help/exit-code/code-1073741819/index.markdown
+++ b/_help/exit-code/code-1073741819/index.markdown
@@ -5,10 +5,10 @@ name: "ec-107374181"
 desc: "Exit Code: -1073741819"
 ---
 # Exit Code: -1073741819 <small>(HEX: 0xC0000005 - STATUS_ACCESS_VIOLATION)</small>
-We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/help/exit-code/code-1073740777/index.markdown) installed.
+We do not yet know the root cause of this issue. In order to solve this issue, some known workarounds include reinstalling the JVM or updating your graphics drivers, this error may also be caused by having ["D3Dgear"](/help/exit-code/code-1073740777/) installed.
 ## How to fix this
 Due to the quite vagueness of the error, we are unsure of the exact cause. Please try the following and attempt to see it they solve your case:
-* [This may possibly be caused by having D3Dgear installed. (If that is the case, please let us know!) ](/help/exit-code/code-1073740777/index.markdown)
+* [This may possibly be caused by having D3Dgear installed. (If that is the case, please let us know!) ](/help/exit-code/code-1073740777/)
 * Try updating your graphics drivers.
 
 


### PR DESCRIPTION
It was pointed out on discord that I added an underscore where there shouldn't be one which lead to the redirect still showing a 404 error: https://discord.com/channels/607127008173883401/777568084114145281/881967787906568202

While it's not working on github I think it should work on the website although I've not tested that