### PR TITLE
Add platform detection to article pages to automatically expand platform-specific <details> sections

### DIFF
--- a/_help/hjt/index.markdown
+++ b/_help/hjt/index.markdown
@@ -14,7 +14,7 @@ For more information, see the [Wikipedia article](https://en.wikipedia.org/wiki/
 Follow the instructions below to generate a HijackThis log.
 
 ### Windows
-<details>
+<details data-platform="windows">
     <summary>Click for instructions</summary>
 
 {{ "
@@ -50,7 +50,7 @@ Click **Submit Anonymously**. On the next page, copy the URL from the address ba
 </details>
 
 ### Mac/Linux
-<details>
+<details data-platform="macos linux">
 	<summary>Click for instructions</summary>
 
 {{"

--- a/_help/hosts-file/index.markdown
+++ b/_help/hosts-file/index.markdown
@@ -70,7 +70,7 @@ Find a folder called **'Altening'** and delete it.
 You then will need to edit your hosts file to undo the changes made by the alt account tools to be able to log in to Minecraft again. Follow the instructions according to your operating system.
 
 ### Windows
-<details>
+<details data-platform="windows">
   <summary>Click for instructions</summary>
 
 {{ "
@@ -164,7 +164,7 @@ Try Minecraft. If Minecraft now works, delete the hosts file from your desktop. 
 </details>
 
 ### Mac
-<details>
+<details data-platform="mac">
   <summary>Click for instructions</summary>
 
 {{ "
@@ -211,7 +211,7 @@ If Minecraft works, close the Terminal window and change your Minecraft password
 </details>
 
 ### Linux
-<details>
+<details data-platform="linux">
   <summary>Click for instructions</summary>
 
 {{ "

--- a/_help/setting-up-java-server/index.markdown
+++ b/_help/setting-up-java-server/index.markdown
@@ -30,7 +30,7 @@ Now follow the OS specific instructions to setup the server. If you're using a l
 
 
 ### Windows {#windows}
-<details>
+<details data-platform="windows" data-urlhash="windows">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -48,7 +48,7 @@ into it, click *Save As*
 </details>
 
 ### MacOS {#macos}
-<details>
+<details data-platform="mac" data-urlhash="macos">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -80,7 +80,7 @@ First, you need to read [the EULA](https://account.mojang.com/documents/minecraf
 ## The Server's Console {#console}
 
 #### Commands
-<details>
+<details data-urlhash="console">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -91,7 +91,7 @@ You can communicate with in game players from the console using `say`, and you c
 
 ##### Stopping the server
 " | markdownify }}
-<details>
+<details data-urlhash="console">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -103,7 +103,7 @@ The best way to stop a server is to run `save-all`, then `stop` once the save ha
 </details>
 
 #### Information {#console-info}
-<details>
+<details data-urlhash="console console-info">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -115,7 +115,7 @@ The console will also display information about how the server is running, if it
 
 
 #### The GUI {#gui}
-<details>
+<details data-urlhash="console gui">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -125,7 +125,7 @@ You may have noticed earlier that the start command contains `-nogui`, this prev
 </details>
 
 #### Running in the background or remotely <small>(MacOS and Linux)</small>
-<details>
+<details data-urlhash="console">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -149,7 +149,7 @@ If you are playing with a person that *is* on the same network as you, for examp
 If you're trying to play with someone that *is not* on the same network as you, for example, if they aren't in the same household as you, please follow the [*Playing Online*](#portforwarding) section
 
 ### Playing Locally {#localplay}
-<details>
+<details data-urlhash="localplay multiplayer">
 	<summary>Click to expand</summary>
 
 {{ "
@@ -175,7 +175,7 @@ If you want to connect to the server on your own computer then do the above but 
 
 ### Playing Online and Port Forwarding {#portforwarding}
 
-<details>
+<details data-urlhash="portforwarding multiplayer">
   <summary>Click to expand</summary>
 
 {{ "

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -34,6 +34,8 @@
       </footer>
     </section>
 
+    <script src="/assets/js/platform-detect.js"></script>
+
     {% if site.google_analytics and jekyll.environment == 'production' %}
       <script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
       <script>

--- a/assets/js/platform-detect.js
+++ b/assets/js/platform-detect.js
@@ -1,0 +1,89 @@
+/**
+ * This implements some simple platform detection so that articles can have
+ * platform-specific `<details>` elements pre-expanded without the user having
+ * to click on it. To add platform detection to an article, you can use it like this:
+ *
+ * ```html
+ * <details data-platform="windows">
+ *   <description>Click for Windows instructions</description>
+ *   [...]
+ * ```
+ *
+ * If a details section is relevant to two platforms (for example, instructions that
+ * work on both Linux and macOS) you can separate them with a space:
+ *
+ * ```html
+ * <details data-platform="macos linux">
+ *   [..]
+ * ```
+ *
+ * To associate a <details> element with a particular URL hash string, you can
+ * use the `data-urlhash` element. This will automatically open that details element
+ * whenever the URL contains that URL hash. This is unrelated to platform detection,
+ * but can be used in conjunction with it to link directly to a part of an article
+ * for a specific platform.
+ *
+ * ```markdown
+ * # Fooing the bar {#fooing-the-bar}
+ *
+ * <details data-urlhash="fooing-the-bar">
+ *   <description>Click for instructions for foo-ing the bar</description>
+ *   [...]
+ * ```
+ */
+(function() {
+    var platformDetailsElements = document.querySelectorAll("details[data-platform]");
+
+    if (platformDetailsElements.length != 0) {
+        var platformDetections = [
+            // we match mobile and console platforms first to avoid detecting some of them as desktop Linux
+            // most platforms can be detected by `navigator.platform`, some are only indicated in the raw ua string
+            { detection: "android", checkFunction: function() { return /Android/.test(window.navigator.userAgent) } },
+            { detection: "ios", check: /^(iPhone|iPod|iPad)/ },
+            { detection: "weird-mobile", check: /^(BlackBerry|Nokia|S60|Symbian|PalmOS|webOS)/ },
+
+            { detection: "xbox", checkFunction: function() { return /Xbox/.test(window.navigator.userAgent) } },
+            { detection: "nintendo", check: /^(New )?Nintendo/ },
+            { detection: "playstation", check: /^(PlayStation|PSP)/i },
+
+            { detection: "windows", check: /^Win/ },
+            // Unix users know how to read Linux instructions
+            { detection: "linux", check: /^(Linux|FreeBSD|OpenBSD|SunOS|X11)/ },
+            { detection: "macos", check: /^Mac/ },
+        ];
+
+        var platform = null;
+
+        for (var heuristic of platformDetections) {
+            if (heuristic.checkFunction == null) {
+                heuristic.checkFunction = function() {
+                    return heuristic.check.test(window.navigator.platform);
+                };
+            }
+
+            if (heuristic.checkFunction()) {
+                platform = heuristic.detection;
+                break;
+            }
+        }
+
+        for (var elem of platformDetailsElements) {
+            if (elem.dataset["platform"].split(" ").indexOf(platform) !== -1) {
+                elem.setAttribute("open", true)
+            }
+        }
+    }
+
+    var urlHashDetailsElements = document.querySelectorAll("details[data-urlhash]");
+
+    function updateUrlHash() {
+        for (var elem of urlHashDetailsElements) {
+            if (elem.dataset["urlhash"].split(" ").indexOf(window.location.hash.slice(1)) !== -1) {
+                elem.setAttribute("open", true)
+            }
+        }
+    }
+
+    updateUrlHash();
+    window.addEventListener("hashchange", updateUrlHash, false);
+})();


### PR DESCRIPTION
This implements some simple platform detection so that articles can have platform-specific `<details>` elements pre-expanded without the user having to click on it. To add platform detection to an article, you can use it like this:

```html
<details data-platform="windows">
  <description>Click for Windows instructions</description>
  [...]
```

If a details section is relevant to two platforms (for example, instructions that work on both Linux and macOS) you can separate them with a space:

```html
<details data-platform="macos linux">
  [..]
```

To associate a `<details>` element with a particular URL hash string, you can use the `data-urlhash` element. This will automatically open that details element whenever the URL contains that URL hash. This is unrelated to platform detection, but can be used in conjunction with it to link directly to a part of an article for a specific platform.

```markdown
# Fooing the bar {#fooing-the-bar}

<details data-urlhash="fooing-the-bar">
  <description>Click for instructions for foo-ing the bar</description>
  [...]
```

My [`java-tutorial-with-platform-detection`](https://github.com/lordofpipes/MinecraftHopper/commit/3c730dec40abb5d5cdc379d3296268f440280492) branch makes this mergeable with my work on the Java installation tutorial article, though since you'll probably want to use a squash commit I'll probably just merge that into this pull request branch when the time comes.