### PR TITLE
Changed wording on setting-up-java-server article

### DIFF
--- a/_help/setting-up-java-server/index.markdown
+++ b/_help/setting-up-java-server/index.markdown
@@ -12,7 +12,7 @@ Minecraft: Java edition uses servers for online play.
 
 ### Hosting Requirements: {#requirements}
 
-* You will need Java installed. For 1.13 and below, you will need to use Oracle Java/OpenJDK 8. For 1.17, you will need to use Oracle Java/OpenJDK 16. For 1.18 and up, you will need to use Oracle Java/OpenJDK 17. You can follow this to [install the right version of Java](/help/installing-java/)
+* You will need Java installed. For 1.13 and below, you will need to use Oracle Java/OpenJDK 8. For 1.17, you will need to use Oracle Java/OpenJDK 16. For 1.18 and above, you will need to use Oracle Java/OpenJDK 17. You can follow this to [install the right version of Java](/help/installing-java/)
 * Minecraft: Java Edition (to join the server)
 * A computer to host it on. This guide has instructions specific to both Windows and MacOS, but a Linux machine should work as well. It is recommended to host a server on a desktop computer, but you can use a laptop as well.
 


### PR DESCRIPTION
This wording was changed as saying '1.18 and up' sounds grammatically inccorect. I've now changed it to '1.18 and above' so it sounds better.

This change gives it the same meaning but it's nicer to read and makes more grammaticle sense.