### PR TITLE
Remove `Gemfile.lock` and add `.jekyll-cache` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@ _site
 .idea/
 .DS_Store
 Jekyll.sh
-Gemfile.lock
 vendor/
+.jekyll-cache


### PR DESCRIPTION
This partially reverts #121, as pushing the `Gemfile.lock` to source control (git) allows everyone to have the same versions of the required gems.