### PR TITLE
Update to remove MalwareBytes as recommended software

### DIFF
--- a/_help/known-incompatible-software/index.html
+++ b/_help/known-incompatible-software/index.html
@@ -167,7 +167,7 @@ softwares:
       Not Detected by ADWCleaner
       Presents like a VPN, Can cause download issues and other issues with the game
 
-      Download [Malwarebytes](http://www.malwarebytes.org/) run a **Scan**, then **Quarentine**. Restart when Malwarebytes tells you to, then try running the game again.
+      Download [BitDefender Free](https://www.bitdefender.com/solutions/free.html) run a **System Scan**. Restart when BitDefender tells you to, then try running the game again.
 
 - name: Game Enhancement Software
   items:

--- a/_help/known-incompatible-software/index.html
+++ b/_help/known-incompatible-software/index.html
@@ -8,7 +8,7 @@ last_updated: 2018-03-01 20:13:00 +0000
 
 softwares:
 - name: Antiviruses and Firewalls
-  description: "Note: We recommend [Malwarebytes](http://www.malwarebytes.org/) as your antivirus."
+  description: "Note: We recommend [BitDefender](https://www.bitdefender.com/) as your antivirus."
   
   items:
   - name: AVG Antivirus
@@ -17,13 +17,6 @@ softwares:
       Causes download problems.
 
       [Uninstall Tool here](http://files-download.avg.com/util/tools/AVG_Remover.exe)
-
-  - name: BitDefender
-    versions: All Versions
-    notes: |
-      Causes download problems, login issues and problems connecting to LAN worlds.
-
-      [Uninstall instructions here](https://www.bitdefender.com/consumer/support/answer/2791/)
 
   - name: ByteFence
     versions: All Versions

--- a/_help/known-incompatible-software/index.html
+++ b/_help/known-incompatible-software/index.html
@@ -8,7 +8,7 @@ last_updated: 2018-03-01 20:13:00 +0000
 
 softwares:
 - name: Antiviruses and Firewalls
-  description: "Note: We recommend [BitDefender](https://www.bitdefender.com/) as your antivirus."
+  description: "Note: We recommend [BitDefender Free](https://www.bitdefender.com/solutions/free.html) as your antivirus."
   
   items:
   - name: AVG Antivirus

--- a/_help/known-incompatible-software/index.html
+++ b/_help/known-incompatible-software/index.html
@@ -8,7 +8,7 @@ last_updated: 2018-03-01 20:13:00 +0000
 
 softwares:
 - name: Antiviruses and Firewalls
-  description: "Note: We recommend [BitDefender Free](https://www.bitdefender.com/solutions/free.html) as your antivirus."
+  description: "Note: We recommend [BitDefender Free](https://www.bitdefender.com/solutions/free.html) as your antivirus. Windows Defender has improved a lot over the years, and is definitely better than some other AVs, like MalwareBytes, but using just Defender should only be your plan of action if you're particularly trying to reduce bloat on your system. Additionally, look up benchmarks on AVs to come to your own conclusions."
   
   items:
   - name: AVG Antivirus


### PR DESCRIPTION
MalwareBytes is not good, and should not be recommended. 

They have since stopped benchmarking it (since it's that bad), but here's a benchmark. https://www.av-comparatives.org/tests/malware-protection-test-september-2022/

As you can see, it has lower detection rates, and higher false positive rates. 

I have also not been able to reproduce the "issues" so called caused by BitDefender, and have likely been fixed. (And even so, it would be trivial to set an exception for Minecraft.) If someone is alone to reproduce this behavior on the newest version of BitDefender, I am happy to back down. 

The bottom line is: we should not be promoting bad software based on what might have been true in the past. 