### PR TITLE
Update navbar links

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -33,10 +33,10 @@
           </button>
           <div class="collapse navbar-collapse" id="navbar">
             <ul class="navbar-nav ms-auto me-3">
-              <li class="nav-item"><a class="nav-link" href="https://account.mojang.com">Mojang Account Page</a></li>
               <li class="nav-item"><a class="nav-link" href="https://minecraft.net">Minecraft Homepage</a></li>
               <li class="nav-item"><a class="nav-link" href="https://bugs.mojang.com/secure/Dashboard.jspa">Bug Tracker</a></li>
               <li class="nav-item"><a class="nav-link" href="http://help.minecraft.net/">Account Support</a></li>
+              <li class="nav-item"><a class="nav-link" href="https://support.xbox.com">Xbox Support</a></li>
             </ul>
           </div>
       </div>


### PR DESCRIPTION
Remove link to Mojang account page because it doesn't exist and redirects to minecraft.net, and add Xbox support link