### PR TITLE
Change sh to bash for Unix HJT

### DIFF
--- a/_help/hjt/index.markdown
+++ b/_help/hjt/index.markdown
@@ -54,7 +54,7 @@ On a Mac, in the Finder, press **Cmd-Space** to open Spotlight, and type **'term
 ![](/static/images/help/hjt/mac-spotlight-terminal.png)
 
 #### Step 2
-In the terminal, type `curl -L https://is.gd/xV3Mxu | sh` and press enter.
+In the terminal, type `curl -L https://is.gd/xV3Mxu | bash` and press enter.
 ![](/static/images/help/hjt/mac-terminal-command.png)
 
 #### Step 3


### PR DESCRIPTION
The usage of double brackets in this script is only supported on `bash`. Some Linux systems have `sh` pointing to `dash`, which does not support double brackets, causing a failure.